### PR TITLE
add disableNameSuffixHash config

### DIFF
--- a/apps/grafana/kustomization.yaml
+++ b/apps/grafana/kustomization.yaml
@@ -19,3 +19,6 @@ configMapGenerator:
   files:
     - dashboards/custom1.json
     - dashboards/custom2.json
+
+generatorOptions:
+  disableNameSuffixHash: true


### PR DESCRIPTION
configMapGenerator adds a hash at the end of the configMap. Grafana was failing because it was looking for 'default-dashboards' but configMapGenerator created a configMap named 'default-dashboards-<some-hash>'

Explanation:
https://pauldally.medium.com/why-is-kustomize-adding-a-bunch-of-characters-to-my-secret-configmap-names-b1572741c846

Adding  `disableNameSuffixHash: true` fixes this.